### PR TITLE
make "sage_root" and "server" configurable options

### DIFF
--- a/sage_patchbot/patchbot.py
+++ b/sage_patchbot/patchbot.py
@@ -669,7 +669,7 @@ class Patchbot(object):
         self.sage_root = self.config["sage_root"]
         self.sage_command = os.path.join(self.sage_root, 'sage')
         self.server = self.config["server"]
-        self.log_dir = os.path.join(self.sage_root, "logs")
+        self.log_dir = os.path.join(self.sage_root, "logs", "patchbot")
 
         # make sure that the log directory is writable and writhe the
         # configuration file there

--- a/sage_patchbot/patchbot.py
+++ b/sage_patchbot/patchbot.py
@@ -341,7 +341,7 @@ class OptionDict(object):
     dry_run = False
     no_banner = False
     owner = None
-    plugin_only = True
+    plugin_only = False
     safe_only = True
     skip_base = True
     def __init__(self, d):


### PR DESCRIPTION
With the patch we allow the option "sage_root" and "server" to be part of the configuration file (and not necessarily the command line). More changes
- rename `get_config` to `get_local_config` since now it does not  consult the server anymore to get the list of trusted users (this is  done in reload_config)
- add a note about optparse vs argparse
- replace options.sage_root by patchbot.sage_root or  patchbot.sage_command in the main loop