### PR TITLE
Fixes for unsafe tickets

### DIFF
--- a/sage_patchbot/patchbot.py
+++ b/sage_patchbot/patchbot.py
@@ -1056,7 +1056,6 @@ class Patchbot(object):
 
                 # ------------- pull and apply -------------
                 pull_from_trac(self.sage_root, ticket['id'], force=True,
-                               use_ccache=self.config['use_ccache'],
                                safe_only=self.config['safe_only'])
                 t.finish("Apply")
                 state = 'applied'

--- a/sage_patchbot/patchbot.py
+++ b/sage_patchbot/patchbot.py
@@ -841,9 +841,9 @@ class Patchbot(object):
 
             self.write_log(u"#{}: start rating".format(ticket['id']), logfile)
 
+            # tickets with milestone sage-feature are main targets of featurebots
             if ticket['milestone'] in ('sage-duplicate/invalid/wontfix',
-                                       'sage-feature', 'sage-pending',
-                                       'sage-wishlist'):
+                                       'sage-pending', 'sage-wishlist'):
                 self.write_log(' do not test if the milestone is not good (got {})'.format(ticket['milestone']),
                                logfile, False)
                 return

--- a/sage_patchbot/patchbot.py
+++ b/sage_patchbot/patchbot.py
@@ -841,7 +841,7 @@ class Patchbot(object):
 
             self.write_log(u"#{}: start rating".format(ticket['id']), logfile)
 
-            # tickets with milestone sage-feature are main targets of featurebots
+            # tickets with milestone sage-feature pass this
             if ticket['milestone'] in ('sage-duplicate/invalid/wontfix',
                                        'sage-pending', 'sage-wishlist'):
                 self.write_log(' do not test if the milestone is not good (got {})'.format(ticket['milestone']),
@@ -849,6 +849,10 @@ class Patchbot(object):
                 return
 
             bonus = self.config['bonus']  # load the dict of bonus
+
+            # tickets with milestone sage-feature get extra bonus
+            if ticket['milestone'] == 'sage-feature':
+                rating += bonus.get('sage-feature', 0)
 
             if ticket.get('git_commit', 'unknown') == 'unknown':
                 self.write_log(' do not test if git_commit is unknown',

--- a/sage_patchbot/trac.py
+++ b/sage_patchbot/trac.py
@@ -297,15 +297,13 @@ def inplace_safe():
 
 
 def pull_from_trac(sage_root, ticket_id, branch=None, force=None,
-                   use_ccache=False,
                    safe_only=False):
     """
     Create four branches from base and ticket.
 
-    If ticket deemed unsafe then clone git repo to temp directory. ?!
+    If ticket deemed unsafe then clone git repo to temp directory.
 
-    Additionally, if ``use_ccache`` then install ccache. Set some global
-    and environment variables.
+    Set some global and environment variables.
 
     There are four branches at play here:
 
@@ -354,10 +352,6 @@ def pull_from_trac(sage_root, ticket_id, branch=None, force=None,
             os.environ['SAGE_ROOT'] = temp_dir
             do_or_die("git branch -f patchbot/base remotes/origin/patchbot/base")
             do_or_die("git branch -f patchbot/ticket_upstream remotes/origin/patchbot/ticket_upstream")
-            if use_ccache:
-                if not os.path.exists('logs'):
-                    os.mkdir('logs')
-                do_or_die("./sage -i ccache")
     except Exception as exn:
         if merge_failure or (not is_safe):
             raise

--- a/sage_patchbot/trac.py
+++ b/sage_patchbot/trac.py
@@ -363,10 +363,6 @@ def pull_from_trac(sage_root, ticket_id, branch=None, force=None,
             raise
         else:
             raise ConfigException(exn.message)
-    finally:
-        if not is_safe and not safe_only:
-            if temp_dir and os.path.exists(temp_dir):
-                shutil.rmtree(temp_dir)  # delete temporary dir
 
 # ===================
 


### PR DESCRIPTION
The temporary dir is supposed to be deleted in patchbot.py starting at line 1213. 
```
        maybe_temp_root = os.environ.get('SAGE_ROOT')
        if maybe_temp_root.endswith(temp_build_suffix + str(ticket['id'])):
            shutil.rmtree(maybe_temp_root) 
```
It should not be deleted here, which causes apply failure for unsafe tickets!

This is related with the issue #98