### PR TITLE
Bump up limit to work around broken sort order

### DIFF
--- a/sage_patchbot/patchbot.py
+++ b/sage_patchbot/patchbot.py
@@ -774,7 +774,7 @@ class Patchbot(object):
 
         A pair (rating, ticket data). The rating is a tuple of integer values.
         """
-        query = "raw&status={}".format(status)
+        query = "raw&status={}&limit=10000".format(status)
 
         self.write_log("Getting ticket list...", LOG_MAIN)
         if self.to_skip:


### PR DESCRIPTION
This works around #116.

Please don't merge this. This is just so people can temporarily fix this on their local patchbots.