### PR TITLE
Remove duplicate url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(name='sage-patchbot',
       license='GPL',
       long_description=long_description,
       long_description_content_type="text/markdown",
-      url='https://github.com/sagemath/sage-patchbot',
       entry_points={
           'console_scripts': ['patchbot=sage_patchbot.patchbot:main']},
       packages=['sage_patchbot', 'sage_patchbot.server'],


### PR DESCRIPTION
Line 34 was duplicating line 29. (Introduced in 95630d3 with missing comma;
missing comma fixed in 0c5652c; but really, no need for duplicate url=...).