### PR TITLE
Fixed finding lazy imports when the import has kwargs.

### DIFF
--- a/sage_patchbot/plugins.py
+++ b/sage_patchbot/plugins.py
@@ -295,8 +295,7 @@ def find_lazy_imports(a_file):
         # will only work for single-line lazy imports
         if line.startswith('lazy_import') and line.endswith(')'):
             what = line[12:-1]
-            if 'deprecation' in what:
-                what = ','.join(what.split(',')[:-1])
+            what = ','.join(term for term in what.split(',') if '=' not in term)  # Filter out kwargs.
             what = u'[' + what + u']'
             what = json.loads(what.replace(u"'", u'"'))
 


### PR DESCRIPTION
Patchbots analysing sage patch 28234 have repeatedly crashed while running with the pyflakes plugin. This was caused by one of the changed files (src/sage/categories/pushout.py) using a `lazy_import('sage.categories.rings', 'Rings', at_startup=True)`. 

While the old version of the code for finding lazy imports previously removed terms that involved the `deprecation=` keyword argument, they did not handle the `at_startup=True` option. This updates the code to ignore all keyword terms. This means that the code does not crash.