### PR TITLE
sage-starts script has moved to build/bin

### DIFF
--- a/sage_patchbot/patchbot.py
+++ b/sage_patchbot/patchbot.py
@@ -1087,7 +1087,7 @@ class Patchbot(object):
                         do_or_die('{} doc-clean'.format(botmake))
                     do_or_die("{} build".format(botmake))
                     do_or_die(os.path.join(self.sage_root,
-                                           'local', 'bin', 'sage-starts'))
+                                           'build', 'bin', 'sage-starts'))
                     # doc is made later in a plugin
                     t.finish("Build")
                     state = 'built'


### PR DESCRIPTION
This fixes the patchbot for use with Sage 9.1.beta9, as mentioned on [sage-release](https://groups.google.com/d/msg/sage-release/kU5M1QVuQQY/rfhP6Ac1BAAJ).