### PR TITLE
Do not build branches that only have CI changes

### DIFF
--- a/sage_patchbot/patchbot.py
+++ b/sage_patchbot/patchbot.py
@@ -56,6 +56,7 @@ from .trac import get_ticket_info_from_trac_server, pull_from_trac, TracServer, 
 from .util import (now_str, prune_pending, do_or_die,
                    get_sage_version, current_reports, git_commit,
                    # branch_updates_some_package,
+                   branch_updates_only_ci,
                    describe_branch, comparable_version, temp_build_suffix,
                    ensure_free_space, get_python_version,
                    ConfigException, SkipTicket, TestsFailed)
@@ -1067,7 +1068,9 @@ class Patchbot(object):
                     print("Ticket updates some package, hence not tested.")
                     self.to_skip[ticket['id']] = time.time() + 240 * 60 * 60
 
-                if not is_spkg:
+                is_ci_only = branch_updates_only_ci()
+
+                if not is_spkg and not is_ci_only:
                     # ------------- make -------------
                     if not self.config['skip_doc_clean']:
                         do_or_die('{} doc-clean doc-uninstall'.format(botmake))

--- a/sage_patchbot/trac.py
+++ b/sage_patchbot/trac.py
@@ -23,6 +23,7 @@ from urllib.request import urlopen
 from .cached_property import cached_property
 from .util import (do_or_die, now_str, describe_branch,
                    temp_build_suffix, ensure_free_space,
+                   branch_updates_only_ci,
                    ConfigException, SkipTicket)
 from .trac_ticket import TracTicket, TracTicket_class
 
@@ -249,6 +250,8 @@ def inplace_safe():
 
     This must be called after the merge has succeeded.
     """
+    if branch_updates_only_ci():
+        return True
     # TODO: Are removed files sufficiently cleaned up?
     cmd = ["git", "diff", "--name-only",
            "patchbot/base..patchbot/ticket_merged"]


### PR DESCRIPTION
This checks changed files against patterns in a manner similar to `inplace_safe`.

Fixes #151