### PR TITLE
sage_patchbot/patchbot.py: Fix/reactivate is_ci_only

### DIFF
--- a/sage_patchbot/patchbot.py
+++ b/sage_patchbot/patchbot.py
@@ -55,7 +55,7 @@ from .trac import get_ticket_info_from_trac_server, pull_from_trac, TracServer, 
 from .util import (now_str, prune_pending, do_or_die,
                    get_sage_version, current_reports, git_commit,
                    # branch_updates_some_package,
-                   # branch_updates_only_ci,
+                   branch_updates_only_ci,
                    describe_branch, comparable_version, temp_build_suffix,
                    ensure_free_space, get_python_version,
                    ConfigException, SkipTicket, TestsFailed)
@@ -1043,10 +1043,11 @@ class Patchbot(object):
                     print("Ticket updates some package, hence not tested.")
                     self.to_skip[ticket['id']] = time.time() + 240 * 60 * 60
 
-                is_ci_only = False  # branch_updates_only_ci()
-                # desactivated for now
+                is_ci_only = branch_updates_only_ci()
 
-                if not is_spkg and not is_ci_only:
+                if is_ci_only:
+                    state = 'tested'
+                elif not is_spkg:
                     # ------------- make -------------
                     if not self.config['skip_doc_clean']:
                         do_or_die('{} doc-clean doc-uninstall'.format(botmake))


### PR DESCRIPTION
Working now - as tested in https://github.com/mkoeppe/sage-patchbot/runs/5172449849?check_suite_focus=true,
reported green checkmark in https://patchbot.sagemath.org/ticket/33196/